### PR TITLE
discard broken sqlite rows

### DIFF
--- a/tools/iface/src/db.rs
+++ b/tools/iface/src/db.rs
@@ -15,6 +15,11 @@ pub type KVIter<'a> = Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + 'a>;
 
 pub type TreeKVIter<'a> = Box<dyn Iterator<Item = (Vec<u8>, KVIter<'a>)> + 'a>;
 
+#[derive(Clone, Copy)]
+pub struct Config {
+    ignore_broken_rows: bool,
+}
+
 pub trait Database {
     fn names<'a>(&'a self) -> Vec<Vec<u8>>;
 

--- a/tools/iface/src/db/sqlite.rs
+++ b/tools/iface/src/db/sqlite.rs
@@ -106,9 +106,22 @@ impl SegmentIter for SqliteSegmentIter<'_> {
     fn iter<'f>(&'f mut self) -> KVIter<'f> {
         Box::new(
             self.0
-                .query_map([], |row| Ok((row.get_unwrap(0), row.get_unwrap(1))))
+                .query_map([], |row| Ok((row.get(0), row.get(1))))
                 .unwrap()
-                .map(|r| r.unwrap()),
+                .map(|x| x.unwrap())
+                .filter_map(|(k, v)| {
+                    let Ok(k) = k else {
+                        println!("ignored a row because its key is malformed");
+                        return None;
+                    };
+
+                    let Ok(v) = v else {
+                        println!("ignored a row because its value is malformed");
+                        return None;
+                    };
+
+                    Some((k, v))
+                }),
         )
     }
 }

--- a/tools/iface/src/db/sqlite.rs
+++ b/tools/iface/src/db/sqlite.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rusqlite::{self, Connection, DatabaseName::Main, Statement};
 use std::{collections::HashSet, iter::FromIterator, path::Path};
 
-use super::{Database, KVIter, Segment, SegmentIter};
+use super::{Config, Database, KVIter, Segment, SegmentIter};
 
 pub fn new_conn<P: AsRef<Path>>(path: P) -> rusqlite::Result<Connection> {
     let path = path.as_ref().join("conduit.db");
@@ -15,13 +15,14 @@ pub fn new_conn<P: AsRef<Path>>(path: P) -> rusqlite::Result<Connection> {
 
 pub struct SqliteDB {
     conn: Connection,
+    config: Config,
 }
 
 const CORRECT_TABLE_SET: &[&str] = &["key", "value"];
 
 impl<'a> SqliteDB {
-    pub fn new(conn: Connection) -> Self {
-        Self { conn }
+    pub fn new(conn: Connection, config: Config) -> Self {
+        Self { conn, config }
     }
 
     fn valid_tables(&self) -> Vec<String> {
@@ -62,6 +63,7 @@ impl Database for SqliteDB {
         Some(Box::new(SqliteSegment {
             conn: &mut self.conn,
             name: string,
+            config: self.config,
         }))
     }
 
@@ -73,6 +75,7 @@ impl Database for SqliteDB {
 pub struct SqliteSegment<'a> {
     conn: &'a mut Connection,
     name: String,
+    config: Config,
 }
 
 impl Segment for SqliteSegment<'_> {
@@ -92,31 +95,47 @@ impl Segment for SqliteSegment<'_> {
     }
 
     fn get_iter(&mut self) -> Box<dyn super::SegmentIter + '_> {
-        Box::new(SqliteSegmentIter(
-            self.conn
+        Box::new(SqliteSegmentIter {
+            statement: self
+                .conn
                 .prepare(format!("SELECT key, value FROM {}", self.name).as_str())
                 .unwrap(),
-        ))
+            config: self.config,
+        })
     }
 }
 
-struct SqliteSegmentIter<'a>(Statement<'a>);
+struct SqliteSegmentIter<'a> {
+    statement: Statement<'a>,
+    config: Config,
+}
 
 impl SegmentIter for SqliteSegmentIter<'_> {
     fn iter<'f>(&'f mut self) -> KVIter<'f> {
+        let config = self.config;
+
         Box::new(
-            self.0
+            self.statement
                 .query_map([], |row| Ok((row.get(0), row.get(1))))
                 .unwrap()
                 .map(|x| x.unwrap())
-                .filter_map(|(k, v)| {
+                .filter_map(move |(k, v)| {
+                    let advice = "You could try using `--ignore-broken-rows` to complete the migration, but take note of its caveats.";
                     let Ok(k) = k else {
-                        println!("ignored a row because its key is malformed");
+                        if config.ignore_broken_rows {
+                            println!("ignored a row because its key is malformed");
+                        } else {
+                            panic!("This row has a malformed key. {}", advice);
+                        }
                         return None;
                     };
 
                     let Ok(v) = v else {
-                        println!("ignored a row because its value is malformed");
+                        if config.ignore_broken_rows {
+                            println!("ignored a row because its value is malformed");
+                        } else {
+                            panic!("This row has a malformed value. {}", advice);
+                        }
                         return None;
                     };
 


### PR DESCRIPTION
I did some database surgery on my SQLite DB which somehow caused some rows to be messed up. This change just discords broken rows instead of panicking, allowing the migration to finish.

I'm not sure what consequences this may have for the new database. Presumably Conduit was already ignoring these rows because, for the ones I saw in `alias_roomid`, there were some rows that looked duplicated.